### PR TITLE
Fix tools folder location after build

### DIFF
--- a/cmake/mission_build.cmake
+++ b/cmake/mission_build.cmake
@@ -280,7 +280,7 @@ function(prepare)
   )
 
   # Generate the tools for the native (host) arch
-  add_subdirectory(${MISSION_SOURCE_DIR}/tools tools)
+  add_subdirectory(${MISSION_SOURCE_DIR}/tools ${MISSION_BINARY_DIR}/tools)
 
   # Add a dependency on the table generator tool as this is required for table builds
   # The "elf2cfetbl" target should have been added by the "tools" above


### PR DESCRIPTION
During cFS build, put the `tools/` folder directly under the `build/` folder instead of `build/central/cfe`, so that other apps can find the correct path to the tools during the build.