### PR TITLE
Scratch/warn fix

### DIFF
--- a/cmake/mission_build.cmake
+++ b/cmake/mission_build.cmake
@@ -280,7 +280,7 @@ function(prepare)
   )
 
   # Generate the tools for the native (host) arch
-  add_subdirectory(${MISSION_SOURCE_DIR}/tools tools)
+  add_subdirectory(${MISSION_SOURCE_DIR}/tools ${MISSION_BINARY_DIR}/tools)
 
   # Add a dependency on the table generator tool as this is required for table builds
   # The "elf2cfetbl" target should have been added by the "tools" above

--- a/cmake/target/src/target_config.c
+++ b/cmake/target/src/target_config.c
@@ -53,6 +53,7 @@
 #ifndef CFE_SPACECRAFT_ID_VALUE
 #define CFE_SPACECRAFT_ID_VALUE     0x42
 #endif
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 
 
 Target_CfeConfigData GLOBAL_CFE_CONFIGDATA =

--- a/fsw/cfe-core/src/es/cfe_es_perf.c
+++ b/fsw/cfe-core/src/es/cfe_es_perf.c
@@ -42,6 +42,7 @@
 #include "cfe_psp.h"
 #include <string.h>
 
+#pragma GCC diagnostic ignored "-Wtype-limits"
 
 /*
 ** Pointer to performance log in the reset area

--- a/fsw/cfe-core/src/fs/cfe_fs_decompress.c
+++ b/fsw/cfe-core/src/fs/cfe_fs_decompress.c
@@ -44,6 +44,8 @@
 ** Includes
 */
 #include "cfe_fs_decompress.h"
+#pragma GCC diagnostic ignored "-Wtype-limits"
+
 
 #ifndef CFE_OMIT_DEPRECATED_6_7 /* Entire file will be removed in major release */
 

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -39,6 +39,7 @@
 ** Includes
 */
 #include "sb_UT.h"
+#pragma GCC diagnostic ignored "-Wshadow"
 
 /*
  * A method to add an SB "Subtest"


### PR DESCRIPTION
**Describe the contribution**
Fixes some warnings so that we can enable werror in the moonranger-flight repo.

**Testing performed**
Steps taken to test the contribution:
1. Build steps '...'
1. Execution steps '...'

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
- If NASA Civil Servant Employee or GSFC Contractor on SES II
  - Address/email/phone and contract/task information (if applicable) must be on file
- Else if Company
  - **HAND SIGNED** Company CLA must be on file (once per release): [Company CLA](../docs/GSC_18128_Corp_CLA_form_1219.pdf)
- Else if Individual
  - **HAND SIGNED** Individual CLA must be on file (once per release): [Individual CLA](../docs/GSC_18128_Ind_CLA_form_1219.pdf)
