### PR TITLE
added stricted compilation flags for tables to avoid a buffer overflow from getting compiled

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -155,7 +155,7 @@ function(add_cfe_tables APP_NAME TBL_SRC_FILES)
       # current content of a dependency (rightfully so).
       add_custom_command(
         OUTPUT "${TABLE_DESTDIR}/${TBLWE}.tbl"
-        COMMAND ${CMAKE_C_COMPILER} ${TBL_CFLAGS} -c -o ${TBLWE}.o ${TBL_SRC}
+        COMMAND ${CMAKE_C_COMPILER} -pedantic -Wall -Wextra -Werror ${TBL_CFLAGS} -c -o ${TBLWE}.o ${TBL_SRC}
         COMMAND ${MISSION_BINARY_DIR}/tools/elf2cfetbl/elf2cfetbl ${TBLWE}.o
         DEPENDS ${MISSION_BINARY_DIR}/tools/elf2cfetbl/elf2cfetbl ${TBL_SRC}
         WORKING_DIRECTORY ${TABLE_DESTDIR}


### PR DESCRIPTION
**Merge this before https://github.com/PlanetaryRobotics/moonranger-rover-flight/pull/1437**

**Describe the contribution**
A clear and concise description of what the contribution is.
- Include explicitly what issue it addresses [e.g. Fixes #X]
We had a buffer overflow with the point-turn plan: the command name was "POINT_TURN" , which exceeded the 8-character limit for a `txt_cmd` field in a `PLAN_Table_t` struct. The new compiler options flags will generate errors for similar and other issues in the future.